### PR TITLE
A few dice command tweaks based on the playtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Originally developed by AwkwardTurtle42, with contributions from natehole and ha
 |`!roll 2d6+2`|2d6 (2+3)+2 = `7`||
 |`!roll 2d6-1`|2d6 (4+5)-1 = `8`||
 |`!roll d66`|d66 = `23`|`!d66`|
+|`!roll character`|_rolls starting statistics for a character/bg||
 
 ### Luck
 
@@ -70,6 +71,7 @@ Manage initiative and random draws of tokens for each new round.
 |Command|Output|Alias|
 |---|---|---|
 |`!init begin`|Battle started. Now add tokens with !init add... (_can also take add tokens in this command_)|`!i begin`, `!begin`, `!start`|
+|`!init begin 2 Goblin 2 Fred`|_alternate invocation that also calls add_||
 |`!init add 4 Goblin 6 Ogre 2 Fred`|Added 4 Goblin tokens. Added 6 Ogre tokens. Added 2 Fred tokens.|`!i add`, `!add`|
 |`!init show`|Show the contents of the initiative bag|`!show`|
 |`!init round`|Starting round 1 of combat! Shuffling the bag... Current Turn: **Goblin**|`!i round`, `!round`|

--- a/cogs/dice_cog.py
+++ b/cogs/dice_cog.py
@@ -24,13 +24,14 @@ class DiceCog(commands.Cog):
                       usage="roll d6|d6+4|2d6|d66|d3")
     async def roll(self, ctx, roll_string: str):
         """Rolls the dice"""
-        D3_REGEXP = re.compile("d3")
-        D6_REGEXP = re.compile("d6([+-][0-9]+)?")
+        D3_REGEXP = re.compile("1?d3([+-][0-9]+)?")
+        D6_REGEXP = re.compile("1?d6([+-][0-9]+)?")
         TWO_D6_REGEXP = re.compile("2d6([+-][0-9]+)?")
         D66_REGEXP = re.compile("d66")
 
         # initialize
         regexp_matched = False
+        modifier = 0
 
         match = D66_REGEXP.match(roll_string)
         if match:
@@ -42,13 +43,16 @@ class DiceCog(commands.Cog):
         if not regexp_matched and match:
             regexp_matched = True
             roll = dice.roll_d3()
-            await ctx.send(f"d3 ({roll}) = `{roll}`")
+
+            if match.group(1):
+                modifier = int(match.group(1))
+
+            await ctx.send(f"d3 ({roll}){modifier_string(modifier)} = `{roll+modifier}`")
 
         match = D6_REGEXP.match(roll_string)
         if not regexp_matched and match:
             regexp_matched = True
             roll = dice.roll_d6()
-            modifier = 0
 
             if match.group(1):
                 modifier = int(match.group(1))
@@ -59,7 +63,6 @@ class DiceCog(commands.Cog):
         if not regexp_matched and match:
             regexp_matched = True
             r1, r2, total = dice.roll_2d6()
-            modifier = 0
 
             if match.group(1):
                 modifier = int(match.group(1))
@@ -69,7 +72,7 @@ class DiceCog(commands.Cog):
         if not regexp_matched:
             raise ArgumentParsingError("Unable to understand your command")
 
-    @commands.command(name="d6", hidden=True)
+    @commands.command(name="d6", aliases=["1d6"], hidden=True)
     async def roll_d6(self, ctx):
         await self.roll(ctx, "d6")
 

--- a/cogs/dice_cog.py
+++ b/cogs/dice_cog.py
@@ -33,6 +33,20 @@ class DiceCog(commands.Cog):
         regexp_matched = False
         modifier = 0
 
+        if roll_string == "character":
+            regexp_matched = True
+            skill_roll = dice.roll_d3()
+            s1, s2, stamina_roll = dice.roll_2d6()
+            luck_roll = dice.roll_d6()
+            bg_roll = dice.roll_d66()
+            _, _, coin_roll = dice.roll_2d6()
+
+            await ctx.send(f"""SKILL d3 ({skill_roll})+3 = `{skill_roll+3}`
+STAMINA 2d6 ({s1}+{s2})+12 = `{stamina_roll+12}`
+LUCK d6 ({luck_roll})+6 = `{luck_roll+6}`
+BACKGROUND d66 = `{bg_roll}`
+COIN: `{coin_roll}` silver pence""")
+
         match = D66_REGEXP.match(roll_string)
         if match:
             regexp_matched = True

--- a/tests/cogs/test_dice_cog.py
+++ b/tests/cogs/test_dice_cog.py
@@ -79,3 +79,22 @@ async def test_roll_d66(mocker):
 
     await dpytest.message("!roll d66")
     dpytest.verify_message("d66 = `23`")
+
+
+@pytest.mark.asyncio
+async def test_roll_character(mocker):
+    tbot = TroikaBot('!')
+    mocker.patch.object(dice, "roll_d3", return_value=2)
+    mocker.patch.object(dice, "roll_d6", return_value=4)
+    mocker.patch.object(dice, "roll_2d6", return_value=(1, 4, 5))
+    mocker.patch.object(dice, "roll_d66", return_value=21)
+    tbot.add_cog(DiceCog(tbot))
+
+    dpytest.configure(tbot)
+
+    await dpytest.message("!roll character")
+    dpytest.verify_message("""SKILL d3 (2)+3 = `5`
+STAMINA 2d6 (1+4)+12 = `17`
+LUCK d6 (4)+6 = `10`
+BACKGROUND d66 = `21`
+COIN: `5` silver pence""")

--- a/tests/cogs/test_dice_cog.py
+++ b/tests/cogs/test_dice_cog.py
@@ -17,16 +17,25 @@ async def test_roll_d3(mocker):
     await dpytest.message("!roll d3")
     dpytest.verify_message("d3 (2) = `2`")
 
+    await dpytest.message("!roll 1d3")
+    dpytest.verify_message("d3 (2) = `2`")
+
+    await dpytest.message("!roll 1d3+6")
+    dpytest.verify_message("d3 (2)+6 = `8`")
+
 
 @pytest.mark.asyncio
 async def test_roll_d6(mocker):
     tbot = TroikaBot('!')
     mocker.patch.object(dice, "roll_d6", return_value=4)
     tbot.add_cog(DiceCog(tbot))
-    
+
     dpytest.configure(tbot)
 
     await dpytest.message("!roll d6")
+    dpytest.verify_message("d6 (4) = `4`")
+
+    await dpytest.message("!roll 1d6")
     dpytest.verify_message("d6 (4) = `4`")
 
     await dpytest.message("!d6")
@@ -35,7 +44,7 @@ async def test_roll_d6(mocker):
     await dpytest.message("!roll d6+2")
     dpytest.verify_message("d6 (4)+2 = `6`")
 
-    await dpytest.message("!roll d6-3")
+    await dpytest.message("!roll 1d6-3")
     dpytest.verify_message("d6 (4)-3 = `1`")
 
 


### PR DESCRIPTION
Just want to support a few more ways to invoke things

- Now support a 1 in front of `d3` and `d6`
- `d3` roller now takes a modifier too
- `roll character` will output a character string

SKILL d3 (3)+3 = `6`
STAMINA 2d6 (6+3)+12 = `21`
LUCK d6 (4)+6 = `10`
BACKGROUND d66 = `43`
COIN: `8` silver pence