### PR TITLE
Fixes for a few initiative bugs found during play

### DIFF
--- a/cogs/initiative_cog.py
+++ b/cogs/initiative_cog.py
@@ -70,9 +70,16 @@ class InitiativeCog(commands.Cog):
                 output_string = f"Unable to parse: {arg}"
         await ctx.send(output_string)
 
-    @init.command(name="remove", help="Removes [number] [tokens] from the bag")
-    async def remove(self, ctx, count: int, token: str):
+    @init.command(name="remove", aliases=["delete", "del"], help="Removes [number] [tokens] from the bag")
+    async def remove(self, ctx, *, arg):
         '''Removes N tokens from the bag'''
+        r = re.match(r'([0-9]+) (.+)$', arg)
+        if not r:
+            raise ArgumentParsingError("Must be of the format `number token_name`")
+
+        token = r.group(2)
+        count = int(r.group(1))
+
         if self.init_tracker is None:
             await ctx.send(NO_INIT_TRACKER_MESSAGE)
             return
@@ -81,11 +88,11 @@ class InitiativeCog(commands.Cog):
         removed = self.init_tracker.remove_token(token, count)
 
         if removed < count:
-            await ctx.send(f"You asked to remove {count} {token} tokens, but there were only {removed} left in the bag")
+            await ctx.send(f"You asked to remove {count} {token} tokens, but only {removed} were in the bag (0 left)")
         elif removed < in_bag:
-            await ctx.send(f"Removed {removed} out of {in_bag} {token} tokens in the bag")
+            await ctx.send(f"Removed {removed} {token} tokens from the bag ({in_bag - removed} left)")
         else:
-            await ctx.send(f"Removed all {removed} {token} tokens from the bag")
+            await ctx.send(f"Removed all {removed} {token} tokens from the bag (0 left)")
 
     @init.command(name="show", aliases=["bag"])
     async def show(self, ctx):

--- a/cogs/models/initiative_tracker.py
+++ b/cogs/models/initiative_tracker.py
@@ -43,6 +43,10 @@ class InitiativeTracker:
         to_remove = min(count, in_bag)
         for _ in range(to_remove):
             self.bag.remove(token)
+            if self.in_round:
+                self.round_bag.remove(token)
+
+        self.shuffle_tokens()
         return to_remove
 
     def current_tokens(self):

--- a/tests/cogs/models/test_initiative_tracker.py
+++ b/tests/cogs/models/test_initiative_tracker.py
@@ -43,6 +43,17 @@ def test_remove_all_tokens_init_tracker():
     assert t.count_token("Goblin") == 0
 
 
+def test_remove_spaces_in_name_init_tracker():
+    t = InitiativeTracker()
+    assert t.count_tokens() == 0
+    t.add_token("Goblin", 4)
+    t.add_token("Vince McFighty", 2)
+    assert t.count_tokens() == 6
+    removed = t.remove_token("Vince McFighty", 2)
+    assert removed == 2
+    assert t.count_tokens() == 4
+
+
 def test_remove_missing_tokens_init_tracker():
     t = InitiativeTracker()
     assert t.count_tokens() == 0
@@ -133,6 +144,26 @@ def test_initiative_shuffles():
     t.start_round()
     turn2 = t.round_bag.copy()
 
+    assert turn1 != turn2
+
+
+def test_remove_shuffle():
+    t = InitiativeTracker()
+    t.add_token("Goblin", 8)
+    t.add_token("Vince McFighty", 2)
+    t.add_token("Ogre", 2)
+
+    t.start_round()
+    turn1 = t.round_bag.copy()
+
+    removed = t.remove_token("Ogre", 2)
+    assert removed == 2
+    turn2 = t.round_bag.copy()
+    assert len(turn1) == 2 + len(turn2)
+
+    turn1.remove("Ogre")
+    turn1.remove("Ogre")
+    assert len(turn1) == len(turn2)
     assert turn1 != turn2
 
 

--- a/tests/cogs/test_initiative_cog.py
+++ b/tests/cogs/test_initiative_cog.py
@@ -84,14 +84,17 @@ async def test_init_cog_remove_tokens():
     await dpytest.message("!i begin")
     dpytest.verify_message("Battle started. Now add tokens with !init add...")
 
-    await dpytest.message("!i add 4 Goblin 6 Ogre 2 Troll")
-    dpytest.verify_message("Added 4 Goblin tokens.\nAdded 6 Ogre tokens.\nAdded 2 Troll tokens.\n")
+    await dpytest.message("!i add 4 Goblin 6 Ogre 2 Troll 2 Vince McFighty")
+    dpytest.verify_message("Added 4 Goblin tokens.\nAdded 6 Ogre tokens.\nAdded 2 Troll tokens.\nAdded 2 Vince McFighty tokens.\n")
 
     await dpytest.message("!i remove 4 Ogre")
-    dpytest.verify_message("Removed 4 out of 6 Ogre tokens in the bag")
+    dpytest.verify_message("Removed 4 Ogre tokens from the bag (2 left)")
 
     await dpytest.message("!i remove 4 Ogre")
-    dpytest.verify_message("You asked to remove 4 Ogre tokens, but there were only 2 left in the bag")
+    dpytest.verify_message("You asked to remove 4 Ogre tokens, but only 2 were in the bag (0 left)")
 
     await dpytest.message("!i remove 4 Goblin")
-    dpytest.verify_message("Removed all 4 Goblin tokens from the bag")
+    dpytest.verify_message("Removed all 4 Goblin tokens from the bag (0 left)")
+
+    await dpytest.message("!i remove 2 Vince McFighty")
+    dpytest.verify_message("Removed all 2 Vince McFighty tokens from the bag (0 left)")


### PR DESCRIPTION
Fix two bugs related to initiative during testing:
1. Remove tokens from the bag during testing should remove from round bag and reshuffle if in a round (actually, should it?)
2. Remove should support space in token name